### PR TITLE
Fetch docList and version at once from DB to fix mismatch issue

### DIFF
--- a/src/webcfg.c
+++ b/src/webcfg.c
@@ -602,6 +602,7 @@ int handlehttpResponse(long response_code, char *webConfigData, int retry_count,
 	int msgpack_status=0;
 	int err = 0;
 	char version[512]={'\0'};
+	char docList[512]={'\0'};
 	uint32_t db_root_version = 0;
 	char *db_root_string = NULL;
 	int subdocList = 0;
@@ -650,7 +651,7 @@ int handlehttpResponse(long response_code, char *webConfigData, int retry_count,
 			if((contentLength !=NULL) && (strcmp(contentLength, "0") == 0))
 			{
 				WebcfgInfo("webConfigData content length is 0\n");
-				refreshConfigVersionList(version, response_code);
+				refreshConfigVersionList(version, response_code, docList);
 				WEBCFG_FREE(contentLength);
 				set_global_contentLen(NULL);
 				WEBCFG_FREE(transaction_uuid);
@@ -709,7 +710,7 @@ int handlehttpResponse(long response_code, char *webConfigData, int retry_count,
 		if (response_code == 404)
 		{
 			//To set POST-NONE root version when 404
-			refreshConfigVersionList(version, response_code);
+			refreshConfigVersionList(version, response_code, docList);
 		}
 		getRootDocVersionFromDBCache(&db_root_version, &db_root_string, &subdocList);
 		addWebConfgNotifyMsg(NULL, db_root_version, NULL, NULL, transaction_uuid, 0, "status", 0, db_root_string, response_code);

--- a/src/webcfg_multipart.c
+++ b/src/webcfg_multipart.c
@@ -238,7 +238,7 @@ WEBCFG_STATUS webcfg_http_request(char **configData, int r_count, int status, lo
 		}
 		if(subdoclist !=NULL)
 		{
-			strcpy(docList, subdoclist);
+			strncpy(docList, subdoclist, sizeof(docList)-1);
 			WEBCFG_FREE(subdoclist);
 		}
 		WebcfgInfo("The get_global_supplementarySync() is %d\n", get_global_supplementarySync());
@@ -1477,7 +1477,7 @@ void refreshConfigVersionList(char *versionsList, int http_status, char *docsLis
 		}
 		WebcfgInfo("versionsList is %s\n", versionsList);
 
-		sprintf(docsList, "%s", "root");
+		snprintf(docsList, 512, "%s", "root");
 		WebcfgDebug("docsList is %s\n", docsList);
 
 		while (NULL != temp)
@@ -1491,7 +1491,7 @@ void refreshConfigVersionList(char *versionsList, int http_status, char *docsLis
 					WEBCFG_FREE(versionsList_tmp);
 					//Fetch docsList and version together to fix docs & version mismatch from DB
 					docsList_tmp = strdup(docsList);
-					sprintf(docsList, "%s,%s",docsList_tmp, temp->name);
+					snprintf(docsList, 512, "%s,%s",docsList_tmp, temp->name);
 					WEBCFG_FREE(docsList_tmp);
 				}
 			}

--- a/src/webcfg_multipart.h
+++ b/src/webcfg_multipart.h
@@ -48,7 +48,6 @@ typedef struct multipartdocs
 
 int readFromFile(char *filename, char **data, int *len);
 WEBCFG_STATUS parseMultipartDocument(void *config_data, char *ct , size_t data_size, char* trans_uuid);
-void getConfigDocList(char *docList);
 void print_tmp_doc_list(size_t mp_count);
 void loadInitURLFromFile(char **url);
 uint32_t get_global_root();
@@ -64,7 +63,7 @@ void set_global_mp(multipartdocs_t *new);
 void reqParam_destroy( int paramCnt, param_t *reqObj );
 void failedDocsRetry();
 WEBCFG_STATUS validate_request_param(param_t *reqParam, int paramCount);
-void refreshConfigVersionList(char *versionsList, int http_status);
+void refreshConfigVersionList(char *versionsList, int http_status, char *docsList);
 char * get_global_contentLen(void);
 void set_global_contentLen(char * value);
 void getRootDocVersionFromDBCache(uint32_t *rt_version, char **rt_string, int *subdoclist);
@@ -84,6 +83,6 @@ int get_multipartdoc_count();
 WEBCFG_STATUS deleteFromMpList(char* doc_name);
 void addToMpList(uint32_t etag, char *name_space, char *data, size_t data_size);
 void delete_mp_doc();
-void createCurlHeader( struct curl_slist *list, struct curl_slist **header_list, int status, char ** trans_uuid);
+void createCurlHeader( struct curl_slist *list, struct curl_slist **header_list, int status, char ** trans_uuid,char **subdocList);
 char *replaceMacWord(const char *s, const char *macW, const char *deviceMACW);
 #endif

--- a/src/webcfg_rbus.c
+++ b/src/webcfg_rbus.c
@@ -2148,7 +2148,6 @@ void rbus_log_handler(
     int threadId,
     char* message)
 {
-    WebcfgDebug("threadId %d\n", threadId);
     const char* slevel = "";
 
     if(level < RBUS_LOG_ERROR)

--- a/tests/test_multipart_unittest.c
+++ b/tests/test_multipart_unittest.c
@@ -180,10 +180,11 @@ void test_createHeader(){
 	struct curl_slist *list = NULL;
 	struct curl_slist *headers_list = NULL;
 	char *transID = NULL;
+	char *subdoclist = NULL;
 	int status=0;
 	curl = curl_easy_init();
 	CU_ASSERT_PTR_NOT_NULL(curl);
-	createCurlHeader(list, &headers_list, status, &transID);
+	createCurlHeader(list, &headers_list, status, &transID, &subdoclist);
 	CU_ASSERT_PTR_NOT_NULL(transID);
 	CU_ASSERT_PTR_NOT_NULL(headers_list);		
 }


### PR DESCRIPTION
To fix IF NONE MATCH header versions and subdocs list mismatch issue when the DB is updated during processing, fetch both the data together at once from DB