### PR TITLE
changing error level to info level

### DIFF
--- a/src/webcfg_rbus.c
+++ b/src/webcfg_rbus.c
@@ -2061,7 +2061,7 @@ void waitForUpstreamEventSubscribe(int wait_time)
 {
 	int count=0;
 	if(!subscribed)
-		WebcfgError("Waiting for %s event subscription for %ds\n", WEBCFG_UPSTREAM_EVENT, wait_time);
+		WebcfgInfo("Waiting for %s event subscription for %ds\n", WEBCFG_UPSTREAM_EVENT, wait_time);
 	while(!subscribed)
 	{
 		sleep(5);


### PR DESCRIPTION
RDKC : 
parodus will subscribe Webconfig.Upstream event. It will take time to subscribe that event.
Before subscribing Webconfig.Upstream event, telemetry execute this function "waitForUpstreamEventSubscribe" and printing that first error. Within 5 minutes ,parodus subscribed that event, So the second error will not print. if exit 5minutes, printing the second error.

From the above scenario, we changed that first error as info level.
"WebcfgError("Waiting for %s event subscription for %ds\n", WEBCFG_UPSTREAM_EVENT, wait_time);" to "WebcfgInfo("Waiting for %s event subscription for %ds\n", WEBCFG_UPSTREAM_EVENT, wait_time);"