### PR TITLE
Fix:previous calculated retry timeout value not resetting for ccsp error

### DIFF
--- a/src/webcfg.c
+++ b/src/webcfg.c
@@ -286,12 +286,15 @@ void *WebConfigMultipartTask(void *status)
 		}
 		else
 		{
+			set_retry_timer(900);
+			set_global_retry_timestamp(0);
+			failedDocsRetry();			
 			if(get_global_retry_timestamp() != 0)
 			{
 				set_retry_timer(retrySyncSeconds());
 			}
 			ts.tv_sec += get_retry_timer();
-			WebcfgDebug("The retry triggers at %s\n", printTime((long long)ts.tv_sec));
+			WebcfgInfo("The retry triggers at %s\n", printTime((long long)ts.tv_sec));
 		}
 		if(get_global_webcfg_forcedsync_needed() == 1 || get_cloud_forcesync_retry_needed() == 1)
 		{


### PR DESCRIPTION
RDKB-58561:Webconfig previous calculated retry timeout value not resetting for ccsp error