### PR TITLE
RDKB-64500 RDKB-64501: Native build for Coverity

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -2,9 +2,9 @@ name: Build Webcfg Component in Native Environment
 
 on:
   push:
-    branches: [ master, 'sprint/**', 'release/**', develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, 'sprint/**', 'release/**', topic/RDK*, develop ]
+    branches: [ master ]
 
 jobs:
   build-webcfg-on-pr:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,30 @@
+name: Build Webcfg Component in Native Environment
+
+on:
+  push:
+    branches: [ master, 'sprint/**', 'release/**', develop ]
+  pull_request:
+    branches: [ master, 'sprint/**', 'release/**', topic/RDK*, develop ]
+
+jobs:
+  build-webcfg-on-pr:
+    name: Build webcfg component in github rdkcentral
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rdkcentral/docker-rdk-ci:latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: native build
+        run: |
+          # Trust the workspace
+          git config --global --add safe.directory '*'
+          # Pull the latest changes for the native build system
+          git submodule update --init --recursive --remote
+          # Build component
+          chmod +x build_tools_workflows/cov_docker_script/build_native.sh
+          ./build_tools_workflows/cov_docker_script/build_native.sh ./cov_docker_script/component_config.json "$(pwd)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.RDKCM_RDKE }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "build_tools_workflows"]
+	path = build_tools_workflows
+	url = https://github.com/rdkcentral/build_tools_workflows 
+	branch = develop

--- a/cov_docker_script/README.md
+++ b/cov_docker_script/README.md
@@ -1,0 +1,3 @@
+# 🔧 Coverity Native Build System for RDK-B Components
+
+The documentation and source for the RDK-B native build system has been centralized in [rdkcentral/build_tools_workflows](https://github.com/rdkcentral/build_tools_workflows/blob/develop/cov_docker_script/README.md)

--- a/cov_docker_script/build_dependencies.sh
+++ b/cov_docker_script/build_dependencies.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -x
+set -e
+##############################
+GITHUB_WORKSPACE="${PWD}"
+ls -la ${GITHUB_WORKSPACE}
+cd ${GITHUB_WORKSPACE}
+
+############################
+# Install CMake 3.22 or higher (required by CMakeLists.txt)
+CMAKE_VERSION="3.22.6"
+CMAKE_DIR="cmake-${CMAKE_VERSION}-linux-x86_64"
+
+# Check if cmake needs upgrade
+NEED_CMAKE_INSTALL=false
+if ! command -v cmake &> /dev/null; then
+    echo "CMake not found, will install ${CMAKE_VERSION}"
+    NEED_CMAKE_INSTALL=true
+else
+    CURRENT_CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')
+    REQUIRED_VERSION="3.22"
+    if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_CMAKE_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+        echo "Current CMake version $CURRENT_CMAKE_VERSION is less than required $REQUIRED_VERSION"
+        NEED_CMAKE_INSTALL=true
+    fi
+fi
+
+if [ "$NEED_CMAKE_INSTALL" = true ]; then
+    echo "Installing CMake ${CMAKE_VERSION}..."
+    wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_DIR}.tar.gz
+    tar -xzf ${CMAKE_DIR}.tar.gz
+    cp -rf ${CMAKE_DIR}/bin/* /usr/local/bin/
+    cp -rf ${CMAKE_DIR}/share/* /usr/local/share/
+    rm -rf ${CMAKE_DIR} ${CMAKE_DIR}.tar.gz
+    echo "CMake ${CMAKE_VERSION} installed successfully"
+fi

--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Component Build Configuration for Coverity/Native Builds",
+  "_version": "2.0",
+  "_description": "Defines dependencies and build settings for the native component",
+  "dependencies": {
+  },
+  "native_component": {
+    "name": "webcfg",
+    "pre_build_commands": [
+      {
+        "command": "chmod +x cov_docker_script/build_dependencies.sh"
+      },
+      {
+        "description": "Check Cmake version",
+        "command": "./cov_docker_script/build_dependencies.sh"
+      }
+    ],
+    "build": {
+      "type": "cmake",
+      "build_dir": "build",
+      "cmake_flags": "-DWEBCONFIG_BIN_SUPPORT:BOOL=true -DWAN_FAILOVER_SUPPORTED:BOOL=true",
+      "parallel_make" :  "false"
+    }
+  }
+}


### PR DESCRIPTION
Reason for change: Enable Coverity scan using native build. 
Test Procedure: All the checks should pass in GitHub 
Risks: Low
Priority: P1
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com