### PR TITLE
RDKB-64501: Updated the native build workflow

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -21,8 +21,14 @@ jobs:
         run: |
           # Trust the workspace
           git config --global --add safe.directory '*'
+
           # Pull the latest changes for the native build system
           git submodule update --init --recursive --remote
+
+          # Build and install dependencies
+          chmod +x cov_docker_script/build_dependencies.sh
+          ./cov_docker_script/build_dependencies.sh
+
           # Build component
           chmod +x build_tools_workflows/cov_docker_script/build_native.sh
           ./build_tools_workflows/cov_docker_script/build_native.sh ./cov_docker_script/component_config.json "$(pwd)"

--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -6,15 +6,6 @@
   },
   "native_component": {
     "name": "webcfg",
-    "pre_build_commands": [
-      {
-        "command": "chmod +x cov_docker_script/build_dependencies.sh"
-      },
-      {
-        "description": "Check Cmake version",
-        "command": "./cov_docker_script/build_dependencies.sh"
-      }
-    ],
     "build": {
       "type": "cmake",
       "build_dir": "build",


### PR DESCRIPTION
Reason for change: The build_dependencies script is executed in the native build workflow
Test Procedure: All the checks should pass in github
Risks: Low
Priority: P1
Signed-off-by:Netaji Panigrahi Netaji_Panigrahi@comcast.com